### PR TITLE
Added a min-width to the resizers to prevent...

### DIFF
--- a/sliderman.css
+++ b/sliderman.css
@@ -124,6 +124,8 @@
 
 .sliderman-panel-inner
 {
+    width: inherit;
+    height: inherit;
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -153,6 +155,7 @@
 
 .sliderman-panel-left .sliderman-resizer, .sliderman-panel-right .sliderman-resizer
 {
+    min-width: 7px;
     width: 7px;
     cursor: col-resize;
     border-left: 1px solid #D8D8D8;
@@ -182,7 +185,7 @@
     -webkit-align-items: center;
     -ms-flex-align: center;
     align-items: center;
-    padding: 0 10px;
+    padding: 10px;
 }
 
 .sliderman-panel-toolbar-title


### PR DESCRIPTION
Added a min-width to the resizers to prevent them from disappearing. The
inner panel now uses parent width and height to prevent overflow being
hidden when scroll bars are rendered.